### PR TITLE
fix: avoid zlib homepage connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,5 @@
 - **插件名称**：ebooks
 - **标识符**：buding
 - **描述**：一个功能强大的电子书搜索和下载插件
-- **版本**：2.0.0
+- **版本**：2.0.1
 - **源码**：[GitHub 地址](https://github.com/zouyonghe/astrbot_plugin_ebooks)

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from data.plugins.astrbot_plugin_ebooks.utils import (
 from data.plugins.astrbot_plugin_ebooks.zlib_source import ZlibSource
 
 
-@register("ebooks", "buding", "一个功能强大的电子书搜索和下载插件", "2.0.0", "https://github.com/zouyonghe/astrbot_plugin_ebooks")
+@register("ebooks", "buding", "一个功能强大的电子书搜索和下载插件", "2.0.1", "https://github.com/zouyonghe/astrbot_plugin_ebooks")
 class ebooks(Star):
     def __init__(self, context: Context, config: AstrBotConfig):
         super().__init__(context)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_ebooks
 desc: 一个功能强大的电子书搜索下载的插件
 help: 输入 /ebooks help 查看关键词回复帮助。
-version: v2.0.0
+version: v2.0.1
 author: buding
 repo: https://github.com/zouyonghe/astrbot_plugin_opds

--- a/tests/test_zlib_source.py
+++ b/tests/test_zlib_source.py
@@ -1,0 +1,156 @@
+import asyncio
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ASTRBOT_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ASTRBOT_ROOT))
+
+
+class Plain:
+    def __init__(self, text):
+        self.text = text
+
+
+class Image:
+    @classmethod
+    def fromBase64(cls, data):
+        return cls()
+
+
+class Node:
+    def __init__(self, uin=None, name=None, content=None):
+        self.uin = uin
+        self.name = name
+        self.content = content or []
+
+
+class Nodes:
+    def __init__(self, nodes=None):
+        self.nodes = nodes or []
+
+
+class File:
+    def __init__(self, name=None, file=None):
+        self.name = name
+        self.file = file
+
+
+class Logger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+    def debug(self, *args, **kwargs):
+        pass
+
+
+astrbot_all = types.ModuleType("astrbot.api.all")
+astrbot_all.Plain = Plain
+astrbot_all.Image = Image
+astrbot_all.Node = Node
+astrbot_all.Nodes = Nodes
+astrbot_all.File = File
+astrbot_all.logger = Logger()
+sys.modules.setdefault("astrbot", types.ModuleType("astrbot"))
+sys.modules.setdefault("astrbot.api", types.ModuleType("astrbot.api"))
+sys.modules["astrbot.api.all"] = astrbot_all
+
+
+class FakeZlibrary:
+    def __init__(self, email=None, password=None):
+        self.logged_in = bool(email and password)
+        self.search_called = False
+
+    def isLoggedIn(self):
+        return self.logged_in
+
+    def login(self, email, password):
+        self.logged_in = bool(email and password)
+
+    def search(self, message=None, limit=None):
+        self.search_called = True
+        return {
+            "books": [
+                {
+                    "title": "Million Pound Note",
+                    "author": "Mark Twain",
+                    "year": "1893",
+                    "publisher": None,
+                    "language": "English",
+                    "description": "A short story.",
+                    "id": "12345",
+                    "hash": "abcdef",
+                }
+            ]
+        }
+
+
+zlibrary_module = types.ModuleType("data.plugins.astrbot_plugin_ebooks.Zlibrary")
+zlibrary_module.Zlibrary = FakeZlibrary
+sys.modules["data.plugins.astrbot_plugin_ebooks.Zlibrary"] = zlibrary_module
+
+
+utils_module = types.ModuleType("data.plugins.astrbot_plugin_ebooks.utils")
+
+
+async def inaccessible_url(*args, **kwargs):
+    return False
+
+
+async def no_cover(*args, **kwargs):
+    return None
+
+
+utils_module.download_and_convert_to_base64 = no_cover
+utils_module.is_base64_image = lambda value: False
+utils_module.is_url_accessible = inaccessible_url
+utils_module.is_valid_zlib_book_hash = lambda value: True
+utils_module.is_valid_zlib_book_id = lambda value: True
+utils_module.truncate_filename = lambda value: value
+sys.modules["data.plugins.astrbot_plugin_ebooks.utils"] = utils_module
+
+from data.plugins.astrbot_plugin_ebooks.zlib_source import ZlibSource
+
+
+class Config(dict):
+    def save_config(self):
+        pass
+
+
+class Event:
+    def get_self_id(self):
+        return "10000"
+
+
+class ZlibSourceTest(unittest.TestCase):
+    def test_search_uses_zlibrary_api_even_when_homepage_head_is_blocked(self):
+        source = ZlibSource(
+            Config(
+                {
+                    "enable_zlib": True,
+                    "zlib_email": "user@example.com",
+                    "zlib_password": "password",
+                }
+            ),
+            proxy=None,
+            max_results=20,
+            temp_path="/tmp",
+        )
+
+        result = asyncio.run(source.search_nodes(Event(), "百万英镑", 20))
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(1, len(result))
+        self.assertTrue(source.zlibrary.search_called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zlib_source.py
+++ b/tests/test_zlib_source.py
@@ -92,6 +92,7 @@ class FakeZlibrary:
 
     def login(self, email, password):
         self.logged_in = bool(email and password)
+        return {"success": self.logged_in}
 
     def search(self, message=None, limit=None):
         self.search_called = True
@@ -123,8 +124,15 @@ async def no_cover(*args, **kwargs):
     return None
 
 
+async def fail_url_accessible(*args, **kwargs):
+    utils_module.url_accessible_called = True
+    raise AssertionError("is_url_accessible() should not be called during Z-Library search")
+
+
+utils_module.url_accessible_called = False
 utils_module.download_and_convert_to_base64 = no_cover
 utils_module.is_base64_image = lambda value: False
+utils_module.is_url_accessible = fail_url_accessible
 utils_module.is_valid_zlib_book_hash = lambda value: True
 utils_module.is_valid_zlib_book_id = lambda value: True
 utils_module.truncate_filename = lambda value: value
@@ -160,6 +168,7 @@ class ZlibSourceTest(unittest.IsolatedAsyncioTestCase):
                 sys.modules[name] = module
 
     async def test_search_uses_zlibrary_api_without_homepage_probe(self):
+        utils_module.url_accessible_called = False
         source = ZlibSource(
             Config(
                 {
@@ -178,6 +187,7 @@ class ZlibSourceTest(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(1, len(result))
         self.assertTrue(source.zlibrary.search_called)
+        self.assertFalse(utils_module.url_accessible_called)
 
 
 if __name__ == "__main__":

--- a/tests/test_zlib_source.py
+++ b/tests/test_zlib_source.py
@@ -1,12 +1,13 @@
 import asyncio
+import importlib.util
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
 
 
-ASTRBOT_ROOT = Path(__file__).resolve().parents[4]
-sys.path.insert(0, str(ASTRBOT_ROOT))
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 
 
 class Plain:
@@ -62,6 +63,11 @@ astrbot_all.logger = Logger()
 sys.modules.setdefault("astrbot", types.ModuleType("astrbot"))
 sys.modules.setdefault("astrbot.api", types.ModuleType("astrbot.api"))
 sys.modules["astrbot.api.all"] = astrbot_all
+sys.modules.setdefault("data", types.ModuleType("data"))
+sys.modules.setdefault("data.plugins", types.ModuleType("data.plugins"))
+plugin_package = types.ModuleType("data.plugins.astrbot_plugin_ebooks")
+plugin_package.__path__ = [str(PLUGIN_ROOT)]
+sys.modules["data.plugins.astrbot_plugin_ebooks"] = plugin_package
 
 
 class FakeZlibrary:
@@ -101,23 +107,25 @@ sys.modules["data.plugins.astrbot_plugin_ebooks.Zlibrary"] = zlibrary_module
 utils_module = types.ModuleType("data.plugins.astrbot_plugin_ebooks.utils")
 
 
-async def inaccessible_url(*args, **kwargs):
-    return False
-
-
 async def no_cover(*args, **kwargs):
     return None
 
 
 utils_module.download_and_convert_to_base64 = no_cover
 utils_module.is_base64_image = lambda value: False
-utils_module.is_url_accessible = inaccessible_url
 utils_module.is_valid_zlib_book_hash = lambda value: True
 utils_module.is_valid_zlib_book_id = lambda value: True
 utils_module.truncate_filename = lambda value: value
 sys.modules["data.plugins.astrbot_plugin_ebooks.utils"] = utils_module
 
-from data.plugins.astrbot_plugin_ebooks.zlib_source import ZlibSource
+spec = importlib.util.spec_from_file_location(
+    "data.plugins.astrbot_plugin_ebooks.zlib_source",
+    PLUGIN_ROOT / "zlib_source.py",
+)
+zlib_source = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = zlib_source
+spec.loader.exec_module(zlib_source)
+ZlibSource = zlib_source.ZlibSource
 
 
 class Config(dict):
@@ -131,7 +139,7 @@ class Event:
 
 
 class ZlibSourceTest(unittest.TestCase):
-    def test_search_uses_zlibrary_api_even_when_homepage_head_is_blocked(self):
+    def test_search_uses_zlibrary_api_without_homepage_probe(self):
         source = ZlibSource(
             Config(
                 {
@@ -142,7 +150,7 @@ class ZlibSourceTest(unittest.TestCase):
             ),
             proxy=None,
             max_results=20,
-            temp_path="/tmp",
+            temp_path=tempfile.gettempdir(),
         )
 
         result = asyncio.run(source.search_nodes(Event(), "百万英镑", 20))

--- a/tests/test_zlib_source.py
+++ b/tests/test_zlib_source.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib.util
 import sys
 import tempfile
@@ -8,6 +7,19 @@ from pathlib import Path
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+STUBBED_MODULES = (
+    "astrbot",
+    "astrbot.api",
+    "astrbot.api.all",
+    "data",
+    "data.plugins",
+    "data.plugins.astrbot_plugin_ebooks",
+    "data.plugins.astrbot_plugin_ebooks.Zlibrary",
+    "data.plugins.astrbot_plugin_ebooks.utils",
+    "data.plugins.astrbot_plugin_ebooks.zlib_source",
+)
+_MISSING = object()
+ORIGINAL_MODULES = {name: sys.modules.get(name, _MISSING) for name in STUBBED_MODULES}
 
 
 class Plain:
@@ -138,8 +150,16 @@ class Event:
         return "10000"
 
 
-class ZlibSourceTest(unittest.TestCase):
-    def test_search_uses_zlibrary_api_without_homepage_probe(self):
+class ZlibSourceTest(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def tearDownClass(cls):
+        for name, module in ORIGINAL_MODULES.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    async def test_search_uses_zlibrary_api_without_homepage_probe(self):
         source = ZlibSource(
             Config(
                 {
@@ -153,7 +173,7 @@ class ZlibSourceTest(unittest.TestCase):
             temp_path=tempfile.gettempdir(),
         )
 
-        result = asyncio.run(source.search_nodes(Event(), "百万英镑", 20))
+        result = await source.search_nodes(Event(), "百万英镑", 20)
 
         self.assertIsInstance(result, list)
         self.assertEqual(1, len(result))

--- a/zlib_source.py
+++ b/zlib_source.py
@@ -8,7 +8,6 @@ from data.plugins.astrbot_plugin_ebooks.Zlibrary import Zlibrary
 from data.plugins.astrbot_plugin_ebooks.utils import (
     download_and_convert_to_base64,
     is_base64_image,
-    is_url_accessible,
     is_valid_zlib_book_hash,
     is_valid_zlib_book_id,
     truncate_filename,
@@ -74,9 +73,6 @@ class ZlibSource:
     async def search_nodes(self, event, query: str, limit: int = 0):
         if not self.config.get("enable_zlib", False):
             return "[Z-Library] 功能未启用。"
-
-        if not await is_url_accessible("https://z-library.sk", proxy=self.proxy):
-            return "[Z-Library] 无法连接到 Z-Library。"
 
         if not query:
             return "[Z-Library] 请提供电子书关键词以进行搜索。"
@@ -163,9 +159,6 @@ class ZlibSource:
 
         if not is_valid_zlib_book_id(book_id) or not is_valid_zlib_book_hash(book_hash):
             return [event.plain_result("[Z-Library] 请使用 /zlib download <id> <hash> 下载。")]
-
-        if not await is_url_accessible("https://z-library.sk", proxy=self.proxy):
-            return [event.plain_result("[Z-Library] 无法连接到 Z-Library。")]
 
         try:
             if not self._ensure_login():


### PR DESCRIPTION
## Summary
- remove the brittle Z-Library homepage HEAD connectivity check before search/download
- rely on the authenticated Z-Library API calls and existing retry/error handling
- bump plugin version to 2.0.1

## Tests
- python3 -m unittest tests/test_zlib_source.py
- python3 -m py_compile main.py zlib_source.py utils.py Zlibrary.py tests/test_zlib_source.py

Fixes #9

## 由 Sourcery 提供的总结

移除对 Z-Library 主页的连通性探测，改为在更新插件元数据和测试时依赖已认证的 API 使用。

Bug 修复：
- 通过移除脆弱的连通性检查，防止在主页的 HEAD 请求被阻止时，Z-Library 的搜索和下载失败。

增强：
- 将 ebooks 插件的版本和元数据从 2.0.0 提升到 2.0.1，以反映行为变化。

测试：
- 添加单元测试，以验证 Z-Library 搜索在不依赖主页可访问性的情况下使用 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除对 Z-Library 主页连通性检查的依赖，并提升 ebooks 插件的元数据版本。

Bug 修复：
- 通过移除脆弱的主页 HEAD 连通性探测，改为依赖已认证的 API 调用，防止 Z-Library 搜索和下载失败。

增强：
- 将 ebooks 插件版本和元数据从 2.0.0 更新到 2.0.1，以反映行为变化。

测试：
- 新增一个异步单元测试，以验证 Z-Library 搜索在无需主页可访问性的情况下使用 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove reliance on Z-Library homepage connectivity checks and bump the ebooks plugin metadata version.

Bug Fixes:
- Prevent Z-Library search and download failures by removing the brittle homepage HEAD connectivity probe and relying on authenticated API calls instead.

Enhancements:
- Update ebooks plugin version and metadata from 2.0.0 to 2.0.1 to reflect the behavioral change.

Tests:
- Add an async unit test to verify Z-Library search uses the API without requiring homepage accessibility.

</details>

</details>

Bug Fixes（错误修复）:
- 通过移除脆弱的连通性检查，防止当主页的 HEAD 请求被阻止时，Z-Library 的搜索和下载失败。

Enhancements（增强）:
- 将 ebooks 插件版本提升至 2.0.1，以反映行为上的变更。

Tests（测试）:
- 添加单元测试，以确保即使主页无法访问，Z-Library 搜索仍然使用 API。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

移除对 Z-Library 主页的连通性探测，改为在更新插件元数据和测试时依赖已认证的 API 使用。

Bug 修复：
- 通过移除脆弱的连通性检查，防止在主页的 HEAD 请求被阻止时，Z-Library 的搜索和下载失败。

增强：
- 将 ebooks 插件的版本和元数据从 2.0.0 提升到 2.0.1，以反映行为变化。

测试：
- 添加单元测试，以验证 Z-Library 搜索在不依赖主页可访问性的情况下使用 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

移除对 Z-Library 主页连通性检查的依赖，并提升 ebooks 插件的元数据版本。

Bug 修复：
- 通过移除脆弱的主页 HEAD 连通性探测，改为依赖已认证的 API 调用，防止 Z-Library 搜索和下载失败。

增强：
- 将 ebooks 插件版本和元数据从 2.0.0 更新到 2.0.1，以反映行为变化。

测试：
- 新增一个异步单元测试，以验证 Z-Library 搜索在无需主页可访问性的情况下使用 API。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove reliance on Z-Library homepage connectivity checks and bump the ebooks plugin metadata version.

Bug Fixes:
- Prevent Z-Library search and download failures by removing the brittle homepage HEAD connectivity probe and relying on authenticated API calls instead.

Enhancements:
- Update ebooks plugin version and metadata from 2.0.0 to 2.0.1 to reflect the behavioral change.

Tests:
- Add an async unit test to verify Z-Library search uses the API without requiring homepage accessibility.

</details>

</details>

</details>